### PR TITLE
[BE] 토큰을 통해 서비스 접근 시 토큰 검증 로직 추가Be refactor/verified member

### DIFF
--- a/src/main/java/com/OmObe/OmO/Board/controller/BoardController.java
+++ b/src/main/java/com/OmObe/OmO/Board/controller/BoardController.java
@@ -55,14 +55,14 @@ public class BoardController {
     public ResponseEntity postBoard(@Valid @RequestBody BoardDto.Post postDto,
                                     @RequestHeader("Authorization") String token){
         Board board = mapper.boardPostDtoToBoard(postDto);
-        Member writer = tokenDecryption.getWriterInJWTToken(token);
-        board.setMember(writer);
+//        Member writer = tokenDecryption.getWriterInJWTToken(token);
+//        board.setMember(writer);
 
-        Board createdBoard = boardService.createBoard(board);
+        Board createdBoard = boardService.createBoard(board, token);
         BoardDto.Response response = mapper.boardToBoardResponseDto(createdBoard);
 
         // 게시판 글 작성 시 사용자의 프로필 이미지 설정
-        response.setProfileURL(writer.getProfileImageUrl());
+        response.setProfileURL(createdBoard.getMember().getProfileImageUrl());
         return new ResponseEntity<>(response,
                 HttpStatus.CREATED);
     }
@@ -75,7 +75,7 @@ public class BoardController {
         patchDto.setBoardId(boardId);
 
         Board board = mapper.boardPatchDtoToBoard(patchDto);
-        Board response = boardService.updateBoard(patchDto);
+        Board response = boardService.updateBoard(patchDto, token);
 
         return new ResponseEntity<>(mapper.boardToBoardResponseDto(response),
                 HttpStatus.OK);
@@ -191,8 +191,9 @@ public class BoardController {
     }
 
     @DeleteMapping("/{board-id}")
-    public ResponseEntity deleteBoard(@PathVariable("board-id") @Positive long boardId){
-        boardService.deleteBoard(boardId);
+    public ResponseEntity deleteBoard(@PathVariable("board-id") @Positive long boardId,
+                                      @RequestHeader("Authorization") String token){
+        boardService.deleteBoard(boardId, token);
 
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
@@ -201,7 +202,6 @@ public class BoardController {
     public ResponseEntity likeBoard(@RequestHeader("boardId") long boardId,
                                     @RequestHeader("Authorization") String Token) throws JsonProcessingException {
         Member writer = tokenDecryption.getWriterInJWTToken(Token);
-
 
         boardService.likesBoard(boardId, writer);
         return new ResponseEntity<>(HttpStatus.OK);

--- a/src/main/java/com/OmObe/OmO/Board/dto/BoardDto.java
+++ b/src/main/java/com/OmObe/OmO/Board/dto/BoardDto.java
@@ -43,6 +43,7 @@ public class BoardDto {
     }
 
     @Getter
+    @Setter
     @AllArgsConstructor
     public static class Response{
 
@@ -56,9 +57,5 @@ public class BoardDto {
         private int likeCount;
         private int viewCount;
         private List<CommentDto.Response> comments;
-
-        public void setProfileURL(String profileURL) {
-            this.profileURL = profileURL;
-        }
     }
 }

--- a/src/main/java/com/OmObe/OmO/Board/service/BoardService.java
+++ b/src/main/java/com/OmObe/OmO/Board/service/BoardService.java
@@ -6,11 +6,13 @@ import com.OmObe.OmO.Board.mapper.BoardMapper;
 import com.OmObe.OmO.Board.repository.BoardRepository;
 import com.OmObe.OmO.Liked.entity.Liked;
 import com.OmObe.OmO.Liked.repository.LikedRepository;
+import com.OmObe.OmO.auth.jwt.TokenDecryption;
 import com.OmObe.OmO.exception.BusinessLogicException;
 import com.OmObe.OmO.exception.ExceptionCode;
 import com.OmObe.OmO.member.entity.Member;
 import com.OmObe.OmO.member.repository.MemberRepository;
 import com.OmObe.OmO.member.service.MemberService;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
 import org.springframework.data.jpa.domain.Specification;
@@ -30,25 +32,50 @@ public class BoardService {
     private final MemberService memberService;
     private final MemberRepository memberRepository;
     private final BoardMapper mapper;
+    private final TokenDecryption tokenDecryption;
 
-    public BoardService(BoardRepository boardRepository, LikedRepository likedRepository, MemberService memberService, MemberRepository memberRepository, BoardMapper mapper) {
+    public BoardService(BoardRepository boardRepository, LikedRepository likedRepository, MemberService memberService, MemberRepository memberRepository, BoardMapper mapper, TokenDecryption tokenDecryption) {
         this.boardRepository = boardRepository;
         this.likedRepository = likedRepository;
         this.memberService = memberService;
         this.memberRepository = memberRepository;
         this.mapper = mapper;
+        this.tokenDecryption = tokenDecryption;
     }
 
-    public Board createBoard(Board board){
+    public Board createBoard(Board board, String token) {
+        try {
+            Member member = tokenDecryption.getWriterInJWTToken(token);
+            memberService.verifiedAuthenticatedMember(member.getMemberId());
+            board.setMember(member);
+        } catch (JsonProcessingException je) {
+            throw new RuntimeException(je);
+        } catch (Exception e) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_TOKEN);
+        }
         return boardRepository.save(board);
     }
 
-    public Board updateBoard(BoardDto.Patch patch){
+    public Board updateBoard(BoardDto.Patch patch, String token){
         Board board = mapper.boardPatchDtoToBoard(patch);
         Board findBoard = findBoard(board.getBoardId());
 
+
         // 사용자의 로그인 인증 상태 검증
-        memberService.verifiedAuthenticatedMember(findBoard.getMember().getMemberId());
+        try {
+            /*
+            서버의 오류 등으로 인해 member 테이블에 데이터가 다시 들어가게 된 상황에서 기존 유효 기간이 남아있는
+            토큰으로 접근하면 다른 회원의 정보로 접근할 가능성이 있기 때문에 verifiedAuthenticatedMember를 통해
+            회원의 이메일을 검증하여 회원의 정보와 권한을 파악하여 서비스에 접근 허용 및 제한 한다.
+             */
+            Member member = tokenDecryption.getWriterInJWTToken(token);
+            memberService.verifiedAuthenticatedMember(member.getMemberId());
+            memberService.verifiedAuthenticatedMember(findBoard.getMember().getMemberId());
+        } catch (JsonProcessingException je) {
+            throw new RuntimeException(je);
+        } catch (Exception e) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_TOKEN);
+        }
 
         Optional.ofNullable(board.getTitle())
                 .ifPresent(title -> findBoard.setTitle(title));
@@ -92,16 +119,35 @@ public class BoardService {
                 Sort.by("commentsCount").descending())));
     }
 
-    public void deleteBoard(long boardId){
+    public void deleteBoard(long boardId, String token){
         Board findBoard = findBoard(boardId);
+        memberService.verifiedAuthenticatedMember(findBoard.getMember().getMemberId());
 
         // 사용자 인증 상태 검증
-        memberService.verifiedAuthenticatedMember(findBoard.getMember().getMemberId());
+        try {
+            /*
+            서버의 오류 등으로 인해 member 테이블에 데이터가 다시 들어가게 된 상황에서 기존 유효 기간이 남아있는
+            토큰으로 접근하면 다른 회원의 정보로 접근할 가능성이 있기 때문에 verifiedAuthenticatedMember를 통해
+            회원의 이메일을 검증하여 회원의 정보와 권한을 파악하여 서비스에 접근 허용 및 제한 한다.
+             */
+            Member member = tokenDecryption.getWriterInJWTToken(token);
+            memberService.verifiedAuthenticatedMember(member.getMemberId());
+        } catch (JsonProcessingException je) {
+            throw new RuntimeException(je);
+        } catch (Exception e) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_TOKEN);
+        }
 
         boardRepository.delete(findBoard);
     }
 
     public void likesBoard(long boardId,Member member){
+        // request header에 포함된 토큰이 정상적인 토큰인지 검증
+        try {
+            memberService.verifiedAuthenticatedMember(member.getMemberId());
+        } catch (Exception e) {
+            throw new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND);
+        }
         List<Liked> likedList = likedRepository.findByBoardAndMember(findBoard(boardId), member);
         Liked liked = null;
         if(likedList.size() == 0){

--- a/src/main/java/com/OmObe/OmO/Comment/controller/CommentController.java
+++ b/src/main/java/com/OmObe/OmO/Comment/controller/CommentController.java
@@ -51,12 +51,12 @@ public class CommentController {
     @SneakyThrows
     @PostMapping("/write")
     public ResponseEntity postComment(@Valid @RequestBody CommentDto.Post postDto,
-                                      @RequestHeader("Authorization") String Token){
+                                      @RequestHeader("Authorization") String token){
         Comment comment = mapper.commentPostToComment(postDto);
-        Member writer = getWriterInJWTToken(Token);
-        comment.setMember(writer);
+//        Member writer = getWriterInJWTToken(Token);
+//        comment.setMember(writer);
 
-        Comment response = commentService.createComment(comment);
+        Comment response = commentService.createComment(comment, token);
         return new ResponseEntity<>(mapper.commentToCommentResponseDto(response),
                 HttpStatus.CREATED);
     }
@@ -77,11 +77,12 @@ public class CommentController {
 
     @PatchMapping("/modification/{comment-id}")
     public ResponseEntity patchComment(@Valid @RequestBody CommentDto.Patch patchDto,
-                                       @PathVariable("comment-id") @Positive long commentId){
+                                       @PathVariable("comment-id") @Positive long commentId,
+                                       @RequestHeader("Authorization") String token){
         patchDto.setCommentId(commentId);
 
         Comment comment = mapper.commentPatchDtoToComment(patchDto);
-        Comment response = commentService.updateComment(comment);
+        Comment response = commentService.updateComment(comment, token);
 
         return new ResponseEntity<>(mapper.commentToCommentResponseDto(response),
                 HttpStatus.OK);
@@ -99,8 +100,9 @@ public class CommentController {
     }
 
     @DeleteMapping("/{comment-Id}")
-    public ResponseEntity deleteComment(@PathVariable("comment-Id") @Positive long commentId){
-        commentService.deleteComment(commentId);
+    public ResponseEntity deleteComment(@PathVariable("comment-Id") @Positive long commentId,
+                                        @RequestHeader("Authorization") String token){
+        commentService.deleteComment(commentId, token);
 
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/src/main/java/com/OmObe/OmO/Comment/service/CommentService.java
+++ b/src/main/java/com/OmObe/OmO/Comment/service/CommentService.java
@@ -2,8 +2,12 @@ package com.OmObe.OmO.Comment.service;
 
 import com.OmObe.OmO.Comment.entity.Comment;
 import com.OmObe.OmO.Comment.repository.CommentRepository;
+import com.OmObe.OmO.auth.jwt.TokenDecryption;
 import com.OmObe.OmO.exception.BusinessLogicException;
 import com.OmObe.OmO.exception.ExceptionCode;
+import com.OmObe.OmO.member.entity.Member;
+import com.OmObe.OmO.member.service.MemberService;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
@@ -13,18 +17,65 @@ import java.util.Optional;
 @Service
 public class CommentService {
     private final CommentRepository commentRepository;
+    private final TokenDecryption tokenDecryption;
+    private final MemberService memberService;
 
-    public CommentService(CommentRepository commentRepository) {
+    public CommentService(CommentRepository commentRepository, TokenDecryption tokenDecryption, MemberService memberService) {
         this.commentRepository = commentRepository;
+        this.tokenDecryption = tokenDecryption;
+        this.memberService = memberService;
     }
 
-    public Comment createComment(Comment comment){
+    /**
+     * <댓글 작성>
+     * 1. 토큰 검증
+     * 2. 댓글 저장
+     * @return
+     */
+    public Comment createComment(Comment comment, String token){
+        // 1. 토큰 검증
+        try {
+            Member member = tokenDecryption.getWriterInJWTToken(token);
+            memberService.verifiedAuthenticatedMember(member.getMemberId());
+            comment.setMember(member);
+        } catch (JsonProcessingException je) {
+            throw new RuntimeException(je);
+        } catch (Exception e) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_TOKEN);
+        }
+        // 2. 댓글 저장
         return commentRepository.save(comment);
     }
 
-    public Comment updateComment(Comment comment){
+    /**
+     * <댓글 수정>
+     * 1. 댓글 탐색(존재? or 존재X?)
+     * 2. 토큰 검증
+     * 3. 댓글 내용 수정
+     * @return
+     */
+    public Comment updateComment(Comment comment, String token){
+        // 1. 댓글 탐색(존재? or 존재X?)
         Comment findComment = findComment(comment.getCommentId());
 
+        // 2. 토큰 검증
+        try {
+            /*
+            서버의 오류 등으로 인해 member 테이블에 데이터가 다시 들어가게 된 상황에서 기존 유효 기간이 남아있는
+            토큰으로 접근하면 다른 회원의 정보로 접근할 가능성이 있기 때문에 verifiedAuthenticatedMember를 통해
+            회원의 이메일을 검증하여 회원의 정보와 권한을 파악하여 서비스에 접근 허용 및 제한 한다.
+             */
+            Member member = tokenDecryption.getWriterInJWTToken(token);
+            memberService.verifiedAuthenticatedMember(member.getMemberId());
+            // 댓글 작성자의 토큰과 현재 request header로 들어온 토큰 비교하여 검증
+            memberService.verifiedAuthenticatedMember(findComment.getMember().getMemberId());
+        } catch (JsonProcessingException je) {
+            throw new RuntimeException(je);
+        } catch (Exception e) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_TOKEN);
+        }
+
+        // 3. 댓글 내용 수정
         Optional.ofNullable(comment.getContent())
                 .ifPresent(content -> findComment.setContent(content));
         findComment.setModifiedAt(LocalDateTime.now());
@@ -43,9 +94,34 @@ public class CommentService {
                 Sort.by("createdAt").descending())));
     }
 
-    public void deleteComment(long commentId){
+    /**
+     * <댓글 삭제
+     * 1. 댓글 존재 유무 파악
+     * 2. 토큰 검증
+     * 3. 댓글 삭제
+     */
+    public void deleteComment(long commentId, String token){
+        // 1. 댓글 존재 유무 파악
         Comment findComment = findComment(commentId);
 
+        // 2. 토큰 검증
+        try {
+            /*
+            서버의 오류 등으로 인해 member 테이블에 데이터가 다시 들어가게 된 상황에서 기존 유효 기간이 남아있는
+            토큰으로 접근하면 다른 회원의 정보로 접근할 가능성이 있기 때문에 verifiedAuthenticatedMember를 통해
+            회원의 이메일을 검증하여 회원의 정보와 권한을 파악하여 서비스에 접근 허용 및 제한 한다.
+             */
+            Member member = tokenDecryption.getWriterInJWTToken(token);
+            memberService.verifiedAuthenticatedMember(member.getMemberId());
+            // 댓글 작성자의 토큰과 현재 request header에 포함된 토큰은 비교
+            memberService.verifiedAuthenticatedMember(findComment.getMember().getMemberId());
+        } catch (JsonProcessingException je) {
+            throw new RuntimeException(je);
+        } catch (Exception e) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_TOKEN);
+        }
+
+        // 3. 댓글 삭제ㅜ
         commentRepository.delete(findComment);
     }
 

--- a/src/main/java/com/OmObe/OmO/Review/controller/ReviewController.java
+++ b/src/main/java/com/OmObe/OmO/Review/controller/ReviewController.java
@@ -41,23 +41,24 @@ public class ReviewController {
     @SneakyThrows
     @PostMapping("/write")
     public ResponseEntity postReview(@Valid @RequestBody ReviewDto.Post postDto,
-                                     @RequestHeader("Authorization") String Token){
-        Member writer = tokenDecryption.getWriterInJWTToken(Token);
+                                     @RequestHeader("Authorization") String token){
+//        Member writer = tokenDecryption.getWriterInJWTToken(Token);
 
         Review review = mapper.reviewPostDtoToReview(postDto);
-        review.setMember(writer);
-        Review response = reviewService.createReview(review);
+//        review.setMember(writer);
+        Review response = reviewService.createReview(review, token);
         return new ResponseEntity<>(mapper.reviewToReviewResponseDto(response),
                 HttpStatus.CREATED);
     }
 
     @PatchMapping("/modification")
     public ResponseEntity patchReview(@Valid @RequestBody ReviewDto.Patch patchDto,
-                                      @RequestHeader("review-id") long reviewId){
+                                      @RequestHeader("review-id") long reviewId,
+                                      @RequestHeader("Authorization") String token){
         // patchDto.setReviewId(reviewId);
 
         Review review = mapper.reviewPatchDtoToReview(patchDto);
-        Review response = reviewService.updateReview(review,reviewId);
+        Review response = reviewService.updateReview(review,reviewId, token);
 
         return new ResponseEntity<>(mapper.reviewToReviewResponseDto(response),
                 HttpStatus.OK);
@@ -83,8 +84,9 @@ public class ReviewController {
     }
 
     @DeleteMapping("/{review-Id}")
-    public ResponseEntity deleteReview(@PathVariable("review-Id") @Positive long reviewId){
-        reviewService.deleteReview(reviewId);
+    public ResponseEntity deleteReview(@PathVariable("review-Id") @Positive long reviewId,
+                                       @RequestHeader("Authorization") String token){
+        reviewService.deleteReview(reviewId, token);
 
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/src/main/java/com/OmObe/OmO/Review/service/ReviewService.java
+++ b/src/main/java/com/OmObe/OmO/Review/service/ReviewService.java
@@ -2,9 +2,12 @@ package com.OmObe.OmO.Review.service;
 
 import com.OmObe.OmO.Review.entity.Review;
 import com.OmObe.OmO.Review.repository.ReviewRepository;
+import com.OmObe.OmO.auth.jwt.TokenDecryption;
 import com.OmObe.OmO.exception.BusinessLogicException;
 import com.OmObe.OmO.exception.ExceptionCode;
+import com.OmObe.OmO.member.entity.Member;
 import com.OmObe.OmO.member.service.MemberService;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -18,25 +21,74 @@ import java.util.Optional;
 public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final MemberService memberService;
+    private final TokenDecryption tokenDecryption;
 
-    public ReviewService(ReviewRepository reviewRepository, MemberService memberService) {
+    public ReviewService(ReviewRepository reviewRepository, MemberService memberService, TokenDecryption tokenDecryption) {
         this.reviewRepository = reviewRepository;
         this.memberService = memberService;
+        this.tokenDecryption = tokenDecryption;
     }
 
-    public Review createReview(Review review){
+    /**
+     * <리뷰 작성>
+     * 1. 토큰 검증
+     * 2. 리뷰 저장
+     */
+    public Review createReview(Review review, String token){
+        // 1. 토큰 검증
+        try{
+            /*
+            서버의 오류 등으로 인해 member 테이블에 데이터가 다시 들어가게 된 상황에서 기존 유효 기간이 남아있는
+            토큰으로 접근하면 다른 회원의 정보로 접근할 가능성이 있기 때문에 verifiedAuthenticatedMember를 통해
+            회원의 이메일을 검증하여 회원의 정보와 권한을 파악하여 서비스에 접근 허용 및 제한 한다.
+             */
+            Member member = tokenDecryption.getWriterInJWTToken(token);
+            memberService.verifiedAuthenticatedMember(member.getMemberId());
+            review.setMember(member);
+        }catch (JsonProcessingException je) {
+            throw new RuntimeException(je);
+        } catch (Exception e) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_TOKEN);
+        }
+
+        // 2. 리뷰 저장
         return reviewRepository.save(review);
     }
 
-    public Review updateReview(Review review,long reviewId){
+    /**
+     * <리뷰 수정>
+     * 1. 수정하려는 리뷰의 존재 여부 파악
+     * 2. 토큰 검증
+     * 3. 리뷰 내용 수정
+     * 4. 변경 사항 저장
+     */
+    public Review updateReview(Review review,long reviewId, String token){
+        // 1. 수정하려는 리뷰의 존재 여부 파악
         Review findReview = findReview(reviewId);
 
-        // 사용자 인증 상태 검증
-        memberService.verifiedAuthenticatedMember(findReview.getMember().getMemberId());
+        // 2. 토큰 검증
+        try {
+            /*
+            서버의 오류 등으로 인해 member 테이블에 데이터가 다시 들어가게 된 상황에서 기존 유효 기간이 남아있는
+            토큰으로 접근하면 다른 회원의 정보로 접근할 가능성이 있기 때문에 verifiedAuthenticatedMember를 통해
+            회원의 이메일을 검증하여 회원의 정보와 권한을 파악하여 서비스에 접근 허용 및 제한 한다.
+             */
+            Member member = tokenDecryption.getWriterInJWTToken(token);
+            memberService.verifiedAuthenticatedMember(member.getMemberId());
+            // 리뷰 작성자의 토큰과 현재 request header로 들어온 토큰 비교하여 검증
+            memberService.verifiedAuthenticatedMember(findReview.getMember().getMemberId());
+        } catch (JsonProcessingException je) {
+            throw new RuntimeException(je);
+        } catch (Exception e) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_TOKEN);
+        }
 
+        // 3. 리뷰 내용 수정
         Optional.ofNullable(review.getContent())
                 .ifPresent(content -> findReview.setContent(content));
         findReview.setModifiedAt(LocalDateTime.now());
+
+        // 4. 변경 사항 저장
         return reviewRepository.save(findReview);
     }
 
@@ -50,12 +102,34 @@ public class ReviewService {
                 Sort.by("createdAt").descending()));
     }
 
-    public void deleteReview(long reviewId){
+    /**
+     * <리뷰 삭제>
+     * 1. 삭제하려는 리뷰 존재 여부 파악
+     * 2. 토큰 검증
+     * 3. 리뷰 삭제
+     */
+    public void deleteReview(long reviewId, String token){
+        // 1. 삭제하려는 리뷰 존재 여부 파악
         Review findReview = findReview(reviewId);
 
-        // 사용자 로그인 인증 상태 검증
-        memberService.verifiedAuthenticatedMember(findReview.getMember().getMemberId());
+        // 2. 토큰 검증
+        try {
+            /*
+            서버의 오류 등으로 인해 member 테이블에 데이터가 다시 들어가게 된 상황에서 기존 유효 기간이 남아있는
+            토큰으로 접근하면 다른 회원의 정보로 접근할 가능성이 있기 때문에 verifiedAuthenticatedMember를 통해
+            회원의 이메일을 검증하여 회원의 정보와 권한을 파악하여 서비스에 접근 허용 및 제한 한다.
+             */
+            Member member = tokenDecryption.getWriterInJWTToken(token);
+            memberService.verifiedAuthenticatedMember(member.getMemberId());
+            // 리뷰 작성자의 토큰과 현재 request header로 들어온 토큰 비교하여 검증
+            memberService.verifiedAuthenticatedMember(findReview.getMember().getMemberId());
+        } catch (JsonProcessingException je) {
+            throw new RuntimeException(je);
+        } catch (Exception e) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_TOKEN);
+        }
 
+        // 3. 리뷰 삭제
         reviewRepository.delete(findReview);
     }
 

--- a/src/main/java/com/OmObe/OmO/notice/controller/NoticeController.java
+++ b/src/main/java/com/OmObe/OmO/notice/controller/NoticeController.java
@@ -40,8 +40,9 @@ public class NoticeController {
     // 공지사항 수정
     @PatchMapping("/{noticeId}")
     public ResponseEntity patchNotice(@RequestBody @Valid NoticeDto.Patch patch,
-                                      @PathVariable("noticeId") Long noticeId) {
-        Notice notice = noticeService.patchNotice(patch, noticeId);
+                                      @PathVariable("noticeId") Long noticeId,
+                                      @RequestHeader("Authorization") String token) {
+        Notice notice = noticeService.patchNotice(patch, noticeId, token);
 
         return new ResponseEntity<>(mapper.noticeToNoticeResponseDto(notice), HttpStatus.OK);
     }
@@ -68,8 +69,9 @@ public class NoticeController {
 
     // 공지사항 삭제
     @DeleteMapping("/{noticeId}")
-    public ResponseEntity deleteNotice(@PathVariable("noticeId") Long noticeId) {
-        noticeService.removeNotice(noticeId);
+    public ResponseEntity deleteNotice(@PathVariable("noticeId") Long noticeId,
+                                       @RequestHeader("Authorization") String token) {
+        noticeService.removeNotice(noticeId, token);
 
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/src/main/java/com/OmObe/OmO/report/boardreport/controller/BoardReportController.java
+++ b/src/main/java/com/OmObe/OmO/report/boardreport/controller/BoardReportController.java
@@ -41,8 +41,9 @@ public class BoardReportController {
     // 신고 내용 조회(관리자 전용)
     @GetMapping
     public ResponseEntity getBoardReports(@RequestParam @Positive int page,
-                                          @RequestParam @Positive int size) {
-        Page<BoardReport> boardReports = boardReportService.getBoardReports(page, size);
+                                          @RequestParam @Positive int size,
+                                          @RequestHeader("Authorization") String token) {
+        Page<BoardReport> boardReports = boardReportService.getBoardReports(page, size, token);
         List<BoardReport> boardReportList = boardReports.getContent();
 
         return new ResponseEntity<>(

--- a/src/main/java/com/OmObe/OmO/report/boardreport/service/BoardReportService.java
+++ b/src/main/java/com/OmObe/OmO/report/boardreport/service/BoardReportService.java
@@ -28,9 +28,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class BoardReportService {
     private final BoardReportRepository boardReportRepository;
     private final BoardReportMapper mapper;
-    private final MemberService memberService;
     private final BoardService boardService;
     private final TokenDecryption tokenDecryption;
+    private final MemberService memberService;
 
 
     /**
@@ -56,7 +56,6 @@ public class BoardReportService {
         BoardReport boardReport = mapper.boardReportPostDtoToBoardReport(post);
         try {
             Member member = tokenDecryption.getWriterInJWTToken(token);
-            memberService.verifiedAuthenticatedMember(member.getMemberId());
             boardReport.setMember(member);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/OmObe/OmO/report/boardreport/service/BoardReportService.java
+++ b/src/main/java/com/OmObe/OmO/report/boardreport/service/BoardReportService.java
@@ -66,7 +66,7 @@ public class BoardReportService {
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         } catch (Exception e) {
-            throw new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND);
+            throw new BusinessLogicException(ExceptionCode.INVALID_TOKEN);
         }
         boardReport.setBoard(board);
 

--- a/src/main/java/com/OmObe/OmO/report/boardreport/service/BoardReportService.java
+++ b/src/main/java/com/OmObe/OmO/report/boardreport/service/BoardReportService.java
@@ -55,7 +55,13 @@ public class BoardReportService {
         // 3. 인증된 사용자와 게시글을 boardReport 객체에 저장
         BoardReport boardReport = mapper.boardReportPostDtoToBoardReport(post);
         try {
+            /*
+            서버의 오류 등으로 인해 member 테이블에 데이터가 다시 들어가게 된 상황에서 기존 유효 기간이 남아있는
+            토큰으로 접근하면 다른 회원의 정보로 접근할 가능성이 있기 때문에 verifiedAuthenticatedMember를 통해
+            회원의 이메일을 검증하여 회원의 정보와 권한을 파악하여 서비스에 접근 허용 및 제한 한다.
+             */
             Member member = tokenDecryption.getWriterInJWTToken(token);
+            memberService.verifiedAuthenticatedMember(member.getMemberId());
             boardReport.setMember(member);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
@@ -70,10 +76,26 @@ public class BoardReportService {
 
     /**
      * <신고 내용 조회 - 관리자 전용>
-     * 1. 먼저 신고된 순으로 정렬(과거순)
+     * 1. 토큰 검증
+     * 2. 먼저 신고된 순으로 정렬(과거순)
      */
-    public Page<BoardReport> getBoardReports(int page, int size) {
-        // 1. 먼저 신고된 순으로 정렬(과거순)
+    public Page<BoardReport> getBoardReports(int page, int size, String token) {
+        // 1. 토큰 검증
+        try {
+            /*
+            서버의 오류 등으로 인해 member 테이블에 데이터가 다시 들어가게 된 상황에서 기존 유효 기간이 남아있는
+            토큰으로 접근하면 다른 회원의 정보로 접근할 가능성이 있기 때문에 verifiedAuthenticatedMember를 통해
+            회원의 이메일을 검증하여 회원의 정보와 권한을 파악하여 서비스에 접근 허용 및 제한 한다.
+             */
+            Member member = tokenDecryption.getWriterInJWTToken(token);
+            memberService.verifiedAuthenticatedMember(member.getMemberId());
+        } catch (JsonProcessingException je) {
+            throw new RuntimeException(je);
+        } catch (Exception e) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_TOKEN);
+        }
+
+        // 2. 먼저 신고된 순으로 정렬(과거순)
         return boardReportRepository.findAll(reportSortedBy(page, size));
     }
 

--- a/src/main/java/com/OmObe/OmO/report/commentreport/controller/CommentReportController.java
+++ b/src/main/java/com/OmObe/OmO/report/commentreport/controller/CommentReportController.java
@@ -37,8 +37,9 @@ public class CommentReportController {
     // 댓글 조회(관리자 전용)
     @GetMapping
     public ResponseEntity getCommentReports(@RequestParam @Positive int page,
-                                            @RequestParam @Positive int size) {
-        Page<CommentReport> commentReports = commentReportService.getCommentReports(page, size);
+                                            @RequestParam @Positive int size,
+                                            @RequestHeader("Authorization") String token) {
+        Page<CommentReport> commentReports = commentReportService.getCommentReports(page, size, token);
         List<CommentReport> commentReportList = commentReports.getContent();
 
         return new ResponseEntity<>(

--- a/src/main/java/com/OmObe/OmO/report/commentreport/service/CommentReportService.java
+++ b/src/main/java/com/OmObe/OmO/report/commentreport/service/CommentReportService.java
@@ -28,7 +28,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommentReportService {
     private final CommentReportRepository commentReportRepository;
     private final CommentReportMapper mapper;
-    private final MemberService memberService;
     private final CommentService commentService;
     private final TokenDecryption tokenDecryption;
 
@@ -54,7 +53,6 @@ public class CommentReportService {
         CommentReport commentReport = mapper.commentReportPostDtoToCommentReport(post);
         try {
             Member member = tokenDecryption.getWriterInJWTToken(token);
-            memberService.verifiedAuthenticatedMember(member.getMemberId());
             commentReport.setMember(member);
         } catch (JsonProcessingException je) {
             throw new RuntimeException(je);

--- a/src/main/java/com/OmObe/OmO/report/commentreport/service/CommentReportService.java
+++ b/src/main/java/com/OmObe/OmO/report/commentreport/service/CommentReportService.java
@@ -30,6 +30,7 @@ public class CommentReportService {
     private final CommentReportMapper mapper;
     private final CommentService commentService;
     private final TokenDecryption tokenDecryption;
+    private final MemberService memberService;
 
     /**
      * <댓글 신고>
@@ -52,12 +53,18 @@ public class CommentReportService {
         // 3. 인증된 사용자와 댓글 정보를 commentReport 객체에 저장
         CommentReport commentReport = mapper.commentReportPostDtoToCommentReport(post);
         try {
+            /*
+            서버의 오류 등으로 인해 member 테이블에 데이터가 다시 들어가게 된 상황에서 기존 유효 기간이 남아있는
+            토큰으로 접근하면 다른 회원의 정보로 접근할 가능성이 있기 때문에 verifiedAuthenticatedMember를 통해
+            회원의 이메일을 검증하여 회원의 정보와 권한을 파악하여 서비스에 접근 허용 및 제한 한다.
+             */
             Member member = tokenDecryption.getWriterInJWTToken(token);
+            memberService.verifiedAuthenticatedMember(member.getMemberId());
             commentReport.setMember(member);
         } catch (JsonProcessingException je) {
             throw new RuntimeException(je);
         } catch (Exception e) {
-            throw new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND);
+            throw new BusinessLogicException(ExceptionCode.INVALID_TOKEN);
         }
         commentReport.setComment(comment);
 
@@ -67,10 +74,21 @@ public class CommentReportService {
 
     /**
      * <신고 내용 조회>
-     * 1. 먼저 신고된 순으로 조회(과거순)
+     * 1. 토큰 검증
+     * 2. 먼저 신고된 순으로 조회(과거순)
      */
-    public Page<CommentReport> getCommentReports(int page, int size) {
-        // 1. 먼저 신고된 순으로 조회(과거순)
+    public Page<CommentReport> getCommentReports(int page, int size, String token) {
+        // 1. 토큰 검증
+        try{
+            Member member = tokenDecryption.getWriterInJWTToken(token);
+            memberService.verifiedAuthenticatedMember(member.getMemberId());
+        }catch (JsonProcessingException je) {
+            throw new RuntimeException(je);
+        } catch (Exception e) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_TOKEN);
+        }
+
+        // 2. 먼저 신고된 순으로 조회(과거순)
         return commentReportRepository.findAll(reportSortedBy(page, size));
     }
 


### PR DESCRIPTION
기존 공지사항 작성과 신고 내용 조회 로직에는 토큰을 통해 해당 회원을 추출하기만 하고 토큰의 소유자의 이메일에 대해 검증하지 않아 토큰의 유효기간이 남아있는 상황에서 서버가 오류 등으로 인해 초기화되어 member 테이블에 다시 데이터가 들어가서 기존 회원의 memberId가 달라지게 된 경우 기존에 유효기간이 남아있던 토큰으로 접근하면 다른 회원의 정보로 접근하는 오류가 발생할 가능성이 있어 검증 코드 추가

 - 게시판 작성, 수정, 삭제 요청 시 포함하는 request header에 있는 토큰 검증

 - 댓글 작성, 수정, 삭제 요청 시 포함하는 request header에 있는 토큰 검증

 - 리뷰 작성, 수정, 삭제 요청 시 포함하는 request header에 있는 토큰 검증

 - 공지사항 작성, 수정, 삭제 요청 시 포함하는 request header에 있는 토큰 검증

 - 신고 내용 작성, 수정, 조회 요청 시 포함하는 request header에 있는 토큰 검증